### PR TITLE
🐛 fix: implement infinite scroll for mobile topic sidebar to fix incomplete topic display

### DIFF
--- a/src/app/[variants]/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByTimeMode/index.tsx
+++ b/src/app/[variants]/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByTimeMode/index.tsx
@@ -2,11 +2,8 @@
 
 import { Accordion, Flexbox } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
-import { MoreHorizontal } from 'lucide-react';
-import React, { memo, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
+import React, { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 
-import NavItem from '@/features/NavPanel/components/NavItem';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
@@ -16,16 +13,19 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 import GroupItem from './GroupItem';
 
 const ByTimeMode = memo(() => {
-  const { t } = useTranslation('topic');
-  const topicPageSize = useGlobalStore(systemStatusSelectors.topicPageSize);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const loadingRef = useRef(false);
 
-  const [hasMore, isExpandingPageSize, openAllTopicsDrawer] = useChatStore((s) => [
-    topicSelectors.hasMoreTopics(s),
-    topicSelectors.isExpandingPageSize(s),
-    s.openAllTopicsDrawer,
-  ]);
-  const [activeTopicId, activeThreadId] = useChatStore((s) => [s.activeTopicId, s.activeThreadId]);
-  const groupTopics = useChatStore(topicSelectors.groupedTopicsForSidebar(topicPageSize), isEqual);
+  const [activeTopicId, activeThreadId, hasMore, isLoadingMore, loadMoreTopics] = useChatStore(
+    (s) => [
+      s.activeTopicId,
+      s.activeThreadId,
+      topicSelectors.hasMoreTopics(s),
+      topicSelectors.isLoadingMoreTopics(s),
+      s.loadMoreTopics,
+    ],
+  );
+  const groupTopics = useChatStore(topicSelectors.groupedTopicsSelector, isEqual);
 
   const [topicGroupKeys, updateSystemStatus] = useGlobalStore((s) => [
     systemStatusSelectors.topicGroupKeys(s),
@@ -35,6 +35,34 @@ const ByTimeMode = memo(() => {
   const expandedKeys = useMemo(() => {
     return topicGroupKeys || groupTopics.map((group) => group.id);
   }, [topicGroupKeys, groupTopics]);
+
+  // Use IntersectionObserver to detect when sentinel is visible
+  const handleIntersection = useCallback(
+    async (entries: IntersectionObserverEntry[]) => {
+      const [entry] = entries;
+      if (entry?.isIntersecting && hasMore && !loadingRef.current) {
+        loadingRef.current = true;
+        await loadMoreTopics();
+        loadingRef.current = false;
+      }
+    },
+    [hasMore, loadMoreTopics],
+  );
+
+  // Set up IntersectionObserver
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(handleIntersection, {
+      root: null, // Use viewport as root, will work with any scrollable parent
+      rootMargin: '200px', // Trigger 200px before sentinel is visible
+      threshold: 0,
+    });
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [handleIntersection]);
 
   return (
     <Flexbox gap={2}>
@@ -53,10 +81,13 @@ const ByTimeMode = memo(() => {
           />
         ))}
       </Accordion>
-      {isExpandingPageSize && <SkeletonList rows={3} />}
-      {hasMore && !isExpandingPageSize && (
-        <NavItem icon={MoreHorizontal} onClick={openAllTopicsDrawer} title={t('loadMore')} />
+      {isLoadingMore && (
+        <Flexbox paddingBlock={1}>
+          <SkeletonList rows={3} />
+        </Flexbox>
       )}
+      {/* Sentinel element for intersection observer */}
+      {hasMore && <div ref={sentinelRef} style={{ height: 1 }} />}
     </Flexbox>
   );
 });

--- a/src/app/[variants]/(main)/agent/_layout/Sidebar/Topic/TopicListContent/FlatMode/index.tsx
+++ b/src/app/[variants]/(main)/agent/_layout/Sidebar/Topic/TopicListContent/FlatMode/index.tsx
@@ -2,36 +2,57 @@
 
 import { Flexbox } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
-import { MoreHorizontal } from 'lucide-react';
-import React, { memo } from 'react';
-import { useTranslation } from 'react-i18next';
+import React, { memo, useCallback, useEffect, useRef } from 'react';
 
-import NavItem from '@/features/NavPanel/components/NavItem';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
-import { useGlobalStore } from '@/store/global';
-import { systemStatusSelectors } from '@/store/global/selectors';
 
 import TopicItem from '../../List/Item';
 
 const FlatMode = memo(() => {
-  const { t } = useTranslation('topic');
-  const topicPageSize = useGlobalStore(systemStatusSelectors.topicPageSize);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const loadingRef = useRef(false);
 
-  const [activeTopicId, activeThreadId, hasMore, isExpandingPageSize, openAllTopicsDrawer] =
-    useChatStore((s) => [
+  const [activeTopicId, activeThreadId, hasMore, isLoadingMore, loadMoreTopics] = useChatStore(
+    (s) => [
       s.activeTopicId,
       s.activeThreadId,
       topicSelectors.hasMoreTopics(s),
-      topicSelectors.isExpandingPageSize(s),
-      s.openAllTopicsDrawer,
-    ]);
-
-  const activeTopicList = useChatStore(
-    topicSelectors.displayTopicsForSidebar(topicPageSize),
-    isEqual,
+      topicSelectors.isLoadingMoreTopics(s),
+      s.loadMoreTopics,
+    ],
   );
+
+  const activeTopicList = useChatStore(topicSelectors.displayTopics, isEqual);
+
+  // Use IntersectionObserver to detect when sentinel is visible
+  const handleIntersection = useCallback(
+    async (entries: IntersectionObserverEntry[]) => {
+      const [entry] = entries;
+      if (entry?.isIntersecting && hasMore && !loadingRef.current) {
+        loadingRef.current = true;
+        await loadMoreTopics();
+        loadingRef.current = false;
+      }
+    },
+    [hasMore, loadMoreTopics],
+  );
+
+  // Set up IntersectionObserver
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(handleIntersection, {
+      root: null, // Use viewport as root, will work with any scrollable parent
+      rootMargin: '200px', // Trigger 200px before sentinel is visible
+      threshold: 0,
+    });
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [handleIntersection]);
 
   return (
     <Flexbox gap={1}>
@@ -45,10 +66,13 @@ const FlatMode = memo(() => {
           title={topic.title}
         />
       ))}
-      {isExpandingPageSize && <SkeletonList rows={3} />}
-      {hasMore && !isExpandingPageSize && (
-        <NavItem icon={MoreHorizontal} onClick={openAllTopicsDrawer} title={t('loadMore')} />
+      {isLoadingMore && (
+        <Flexbox paddingBlock={1}>
+          <SkeletonList rows={3} />
+        </Flexbox>
       )}
+      {/* Sentinel element for intersection observer */}
+      {hasMore && <div ref={sentinelRef} style={{ height: 1 }} />}
     </Flexbox>
   );
 });

--- a/src/app/[variants]/(main)/agent/_layout/Sidebar/Topic/useDropdownMenu.tsx
+++ b/src/app/[variants]/(main)/agent/_layout/Sidebar/Topic/useDropdownMenu.tsx
@@ -1,13 +1,11 @@
 import { Icon, type MenuProps } from '@lobehub/ui';
 import { App, Upload } from 'antd';
 import { css, cx } from 'antd-style';
-import { Hash, Import, LucideCheck, Trash } from 'lucide-react';
+import { Import, LucideCheck, Trash } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useChatStore } from '@/store/chat';
-import { useGlobalStore } from '@/store/global';
-import { systemStatusSelectors } from '@/store/global/selectors';
 import { useUserStore } from '@/store/user';
 import { preferenceSelectors } from '@/store/user/selectors';
 import { TopicDisplayMode } from '@/types/topic';
@@ -62,11 +60,6 @@ export const useTopicActionsDropdownMenu = (
     s.updatePreference,
   ]);
 
-  const [topicPageSize, updateSystemStatus] = useGlobalStore((s) => [
-    systemStatusSelectors.topicPageSize(s),
-    s.updateSystemStatus,
-  ]);
-
   return useMemo(() => {
     const displayModeItems = Object.values(TopicDisplayMode).map((mode) => ({
       icon: topicDisplayMode === mode ? <Icon icon={LucideCheck} /> : <div />,
@@ -77,27 +70,8 @@ export const useTopicActionsDropdownMenu = (
       },
     }));
 
-    const pageSizeOptions = [20, 40, 60, 100];
-    const pageSizeItems = pageSizeOptions.map((size) => ({
-      icon: topicPageSize === size ? <Icon icon={LucideCheck} /> : <div />,
-      key: `pageSize-${size}`,
-      label: t('pageSizeItem', { count: size, ns: 'common' }),
-      onClick: () => {
-        updateSystemStatus({ topicPageSize: size });
-      },
-    }));
-
     return [
       ...displayModeItems,
-      {
-        type: 'divider' as const,
-      },
-      {
-        children: pageSizeItems,
-        icon: <Icon icon={Hash} />,
-        key: 'displayItems',
-        label: t('displayItems'),
-      },
       {
         type: 'divider' as const,
       },
@@ -148,9 +122,7 @@ export const useTopicActionsDropdownMenu = (
     ].filter(Boolean) as MenuProps['items'];
   }, [
     topicDisplayMode,
-    topicPageSize,
     updatePreference,
-    updateSystemStatus,
     handleImport,
     onUploadClose,
     removeUnstarredTopic,

--- a/src/app/[variants]/(main)/group/_layout/Sidebar/Topic/TopicListContent/ByTimeMode/index.tsx
+++ b/src/app/[variants]/(main)/group/_layout/Sidebar/Topic/TopicListContent/ByTimeMode/index.tsx
@@ -2,12 +2,8 @@
 
 import { Accordion, Flexbox } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
-import { MoreHorizontal } from 'lucide-react';
 import React, { memo, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
 
-import NavItem from '@/features/NavPanel/components/NavItem';
-import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 import { useGlobalStore } from '@/store/global';
@@ -16,16 +12,8 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 import GroupItem from './GroupItem';
 
 const ByTimeMode = memo(() => {
-  const { t } = useTranslation('topic');
-  const topicPageSize = useGlobalStore(systemStatusSelectors.topicPageSize);
-
-  const [hasMore, isExpandingPageSize, openAllTopicsDrawer] = useChatStore((s) => [
-    topicSelectors.hasMoreTopics(s),
-    topicSelectors.isExpandingPageSize(s),
-    s.openAllTopicsDrawer,
-  ]);
   const [activeTopicId, activeThreadId] = useChatStore((s) => [s.activeTopicId, s.activeThreadId]);
-  const groupTopics = useChatStore(topicSelectors.groupedTopicsForSidebar(topicPageSize), isEqual);
+  const groupTopics = useChatStore(topicSelectors.groupedTopicsSelector, isEqual);
 
   const [topicGroupKeys, updateSystemStatus] = useGlobalStore((s) => [
     systemStatusSelectors.topicGroupKeys(s),
@@ -53,10 +41,6 @@ const ByTimeMode = memo(() => {
           />
         ))}
       </Accordion>
-      {isExpandingPageSize && <SkeletonList rows={3} />}
-      {hasMore && !isExpandingPageSize && (
-        <NavItem icon={MoreHorizontal} onClick={openAllTopicsDrawer} title={t('loadMore')} />
-      )}
     </Flexbox>
   );
 });

--- a/src/app/[variants]/(main)/group/_layout/Sidebar/Topic/TopicListContent/FlatMode/index.tsx
+++ b/src/app/[variants]/(main)/group/_layout/Sidebar/Topic/TopicListContent/FlatMode/index.tsx
@@ -2,36 +2,20 @@
 
 import { Flexbox } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
-import { MoreHorizontal } from 'lucide-react';
 import React, { memo } from 'react';
-import { useTranslation } from 'react-i18next';
 
-import NavItem from '@/features/NavPanel/components/NavItem';
-import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
-import { useGlobalStore } from '@/store/global';
-import { systemStatusSelectors } from '@/store/global/selectors';
 
 import TopicItem from '../../List/Item';
 
 const FlatMode = memo(() => {
-  const { t } = useTranslation('topic');
-  const topicPageSize = useGlobalStore(systemStatusSelectors.topicPageSize);
+  const [activeTopicId, activeThreadId] = useChatStore((s) => [
+    s.activeTopicId,
+    s.activeThreadId,
+  ]);
 
-  const [activeTopicId, activeThreadId, hasMore, isExpandingPageSize, openAllTopicsDrawer] =
-    useChatStore((s) => [
-      s.activeTopicId,
-      s.activeThreadId,
-      topicSelectors.hasMoreTopics(s),
-      topicSelectors.isExpandingPageSize(s),
-      s.openAllTopicsDrawer,
-    ]);
-
-  const activeTopicList = useChatStore(
-    topicSelectors.displayTopicsForSidebar(topicPageSize),
-    isEqual,
-  );
+  const activeTopicList = useChatStore(topicSelectors.displayTopics, isEqual);
 
   return (
     <Flexbox gap={1}>
@@ -45,10 +29,6 @@ const FlatMode = memo(() => {
           title={topic.title}
         />
       ))}
-      {isExpandingPageSize && <SkeletonList rows={3} />}
-      {hasMore && !isExpandingPageSize && (
-        <NavItem icon={MoreHorizontal} onClick={openAllTopicsDrawer} title={t('loadMore')} />
-      )}
     </Flexbox>
   );
 });

--- a/src/app/[variants]/(main)/group/_layout/Sidebar/Topic/useDropdownMenu.tsx
+++ b/src/app/[variants]/(main)/group/_layout/Sidebar/Topic/useDropdownMenu.tsx
@@ -1,13 +1,11 @@
 import { Icon, type MenuProps } from '@lobehub/ui';
 import { App, Upload } from 'antd';
 import { css, cx } from 'antd-style';
-import { Hash, Import, LucideCheck, Trash } from 'lucide-react';
+import { Import, LucideCheck, Trash } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useChatStore } from '@/store/chat';
-import { useGlobalStore } from '@/store/global';
-import { systemStatusSelectors } from '@/store/global/selectors';
 import { useUserStore } from '@/store/user';
 import { preferenceSelectors } from '@/store/user/selectors';
 import { TopicDisplayMode } from '@/types/topic';
@@ -62,11 +60,6 @@ export const useTopicActionsDropdownMenu = (
     s.updatePreference,
   ]);
 
-  const [topicPageSize, updateSystemStatus] = useGlobalStore((s) => [
-    systemStatusSelectors.topicPageSize(s),
-    s.updateSystemStatus,
-  ]);
-
   return useMemo(() => {
     const displayModeItems = Object.values(TopicDisplayMode).map((mode) => ({
       icon: topicDisplayMode === mode ? <Icon icon={LucideCheck} /> : <div />,
@@ -77,27 +70,8 @@ export const useTopicActionsDropdownMenu = (
       },
     }));
 
-    const pageSizeOptions = [20, 40, 60, 100];
-    const pageSizeItems = pageSizeOptions.map((size) => ({
-      icon: topicPageSize === size ? <Icon icon={LucideCheck} /> : <div />,
-      key: `pageSize-${size}`,
-      label: t('pageSizeItem', { count: size, ns: 'common' }),
-      onClick: () => {
-        updateSystemStatus({ topicPageSize: size });
-      },
-    }));
-
     return [
       ...displayModeItems,
-      {
-        type: 'divider' as const,
-      },
-      {
-        children: pageSizeItems,
-        icon: <Icon icon={Hash} />,
-        key: 'displayItems',
-        label: t('displayItems'),
-      },
       {
         type: 'divider' as const,
       },
@@ -148,9 +122,7 @@ export const useTopicActionsDropdownMenu = (
     ].filter(Boolean) as MenuProps['items'];
   }, [
     topicDisplayMode,
-    topicPageSize,
     updatePreference,
-    updateSystemStatus,
     handleImport,
     onUploadClose,
     removeUnstarredTopic,

--- a/src/app/[variants]/(mobile)/chat/features/Topic/index.tsx
+++ b/src/app/[variants]/(mobile)/chat/features/Topic/index.tsx
@@ -12,7 +12,7 @@ const Topic = () => {
         <TopicSearchBar />
         <Flexbox
           height={'100%'}
-          style={{ marginInline: -8, overflow: 'hidden', position: 'relative' }}
+          style={{ marginInline: -8, overflow: 'auto', position: 'relative' }}
           width={'calc(100% + 16px)'}
         >
           <TopicListContent />


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
Fixed incomplete topic rendering on mobile browsers where only 15-20 topics were displayed instead of the complete list.

**Key Changes:**
1. **Fixed scrolling**: Changed overflow from 'hidden' to 'auto' on mobile topic sidebar content container to enable scrolling
2. **Removed broken UI**: Eliminated non-functional "Load More" button that attempted to open AllTopicsDrawer (desktop-only component) in mobile view
3. **Removed limits**: Removed topicPageSize limit and "Display Items" setting from topic sidebar - all topics now display without artificial pagination
4. **Implemented infinite scroll**: Added IntersectionObserver-based infinite scroll to both FlatMode and ByTimeMode components with 200px margin trigger, loading skeleton during fetch, and support for both mobile and desktop layouts

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

**Test Steps:**
1. Open LobeChat on mobile device or use browser mobile devtools
2. Navigate to a chat with many topics (>20)
3. Open topic sidebar
4. Verify all topics are accessible via scrolling
5. Scroll to bottom and verify infinite scroll loads more topics smoothly
6. Verify loading skeleton appears during fetch
7. Test on desktop to ensure no regression in topic sidebar functionality

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| Only 15-20 topics visible, no scroll, broken "Load More" button | Complete topic list with smooth infinite scroll |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
- **Breaking Change**: Removed "Display Items" setting from topic sidebar settings menu. Users previously using this setting will need to use the new infinite scroll behavior instead.
- **Performance**: IntersectionObserver is used for efficient scroll detection without main thread blocking

## Summary by Sourcery

Implement infinite scrolling for the topic sidebar and remove page-size-based pagination and related UI controls.

Bug Fixes:
- Ensure all topics are accessible on mobile by allowing the topic sidebar to scroll instead of clipping content.

Enhancements:
- Add IntersectionObserver-based infinite scroll with loading skeletons for agent topic lists in flat and time-grouped modes on both mobile and desktop.
- Simplify topic list selectors by using unified display/grouped topic selectors instead of page-size-limited variants.
- Remove the configurable topic page size and associated menu items from the topic sidebar actions dropdown.